### PR TITLE
Fixed README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<h1 style="text-align: center;" > Analog Devices 3DToF Image Stitching</p>
+<h1 style="text-align: center;" > Analog Devices 3DToF Image Stitching</h1>
 
 ---
 # Overview


### PR DESCRIPTION
A header tag at the start of the file did not have a closing tag.